### PR TITLE
Generic receiver

### DIFF
--- a/lib/stargate/connection.ex
+++ b/lib/stargate/connection.ex
@@ -46,7 +46,7 @@ defmodule Stargate.Connection do
   @doc """
   TODO
   """
-  @spec connection_settings(keyword(), String.t(), String.t()) :: connection_settings()
+  @spec connection_settings(keyword(), atom(), String.t()) :: connection_settings()
   def connection_settings(opts, type, params) do
     host = Keyword.fetch!(opts, :host) |> format_host()
     protocol = Keyword.get(opts, :protocol, "ws")

--- a/lib/stargate/consumer/query_params.ex
+++ b/lib/stargate/consumer/query_params.ex
@@ -1,0 +1,34 @@
+defmodule Stargate.Consumer.QueryParams do
+  @moduledoc """
+  TODO
+  """
+
+  @doc """
+  TODO
+  """
+  @spec build_params(map() | nil) :: String.t()
+  def build_params(nil), do: ""
+
+  def build_params(config) when is_map(config) do
+    subscription_type =
+      case Map.get(config, :subscription_type) do
+        :exclusive -> "Exclusive"
+          :failover -> "Failover"
+          :shared -> "Shared"
+          _ -> ""
+      end
+    %{
+      "ackTimeoutMillis" => Map.get(config, :ack_timeout),
+      "subscriptionType" => subscription_type,
+      "receiverQueueSize" => Map.get(config, :queue_size),
+      "consumerName" => Map.get(config, :name),
+      "priorityLevel" => Map.get(config, :priority),
+      "maxRedeliverCount" => Map.get(config, :max_redeliver_count),
+      "deadLetterTopic" => Map.get(config, :dead_letter_topic),
+      "pullMode" => Map.get(config, :pull_mode)
+    }
+    |> Enum.map(fn {key, value} -> key <> "=" <> to_string(value) end)
+    |> Enum.filter(fn param -> String.last(param) != "=" end)
+    |> Enum.join("&")
+  end
+end

--- a/lib/stargate/consumer/query_params.ex
+++ b/lib/stargate/consumer/query_params.ex
@@ -13,10 +13,11 @@ defmodule Stargate.Consumer.QueryParams do
     subscription_type =
       case Map.get(config, :subscription_type) do
         :exclusive -> "Exclusive"
-          :failover -> "Failover"
-          :shared -> "Shared"
-          _ -> ""
+        :failover -> "Failover"
+        :shared -> "Shared"
+        _ -> ""
       end
+
     %{
       "ackTimeoutMillis" => Map.get(config, :ack_timeout),
       "subscriptionType" => subscription_type,

--- a/lib/stargate/producer.ex
+++ b/lib/stargate/producer.ex
@@ -125,7 +125,7 @@ defmodule Stargate.Producer do
 
     state =
       args
-      |> Stargate.Connection.connection_settings("producer", query_params)
+      |> Stargate.Connection.connection_settings(:producer, query_params)
       |> Map.put(:query_params, query_params_config)
       |> Map.put(:registry, registry)
       |> (fn fields -> struct(State, fields) end).()

--- a/lib/stargate/reader/query_params.ex
+++ b/lib/stargate/reader/query_params.ex
@@ -19,7 +19,7 @@ defmodule Stargate.Reader.QueryParams do
       end
 
     %{
-      "readerName" => Map.get(config, :reader_name),
+      "readerName" => Map.get(config, :name),
       "receiverQueueSize" => Map.get(config, :queue_size),
       "messageId" => starting_message
     }

--- a/lib/stargate/receiver.ex
+++ b/lib/stargate/receiver.ex
@@ -25,7 +25,7 @@ defmodule Stargate.Receiver do
   def pull_permit(receiver, count) do
     permit = construct_permit(count)
 
-    WebSockex.send_frame(receiver, {:text}, permit)
+    WebSockex.send_frame(receiver, {:text, permit})
   end
 
   @doc """
@@ -90,6 +90,7 @@ defmodule Stargate.Receiver do
     type = Keyword.fetch!(args, :type)
     registry = Keyword.fetch!(args, :registry)
     query_params_config = Keyword.get(args, :query_params)
+
     query_params =
       case type do
         :consumer -> Consumer.QueryParams.build_params(query_params_config)

--- a/lib/stargate/receiver.ex
+++ b/lib/stargate/receiver.ex
@@ -1,9 +1,10 @@
-defmodule Stargate.Reader do
+defmodule Stargate.Receiver do
   @moduledoc """
   TODO
   """
   use Stargate.Connection
   import Stargate.Supervisor, only: [via: 2]
+  alias Stargate.{Consumer, Reader}
 
   @type message_id :: String.t()
 
@@ -15,6 +16,16 @@ defmodule Stargate.Reader do
     ack = construct_response(message_id)
 
     WebSockex.send_frame(receiver, {:text, ack})
+  end
+
+  @doc """
+  TODO
+  """
+  @spec pull_permit(GenServer.server(), non_neg_integer()) :: :ok | {:error, term()}
+  def pull_permit(receiver, count) do
+    permit = construct_permit(count)
+
+    WebSockex.send_frame(receiver, {:text}, permit)
   end
 
   @doc """
@@ -76,9 +87,14 @@ defmodule Stargate.Reader do
 
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(args) do
+    type = Keyword.fetch!(args, :type)
     registry = Keyword.fetch!(args, :registry)
     query_params_config = Keyword.get(args, :query_params)
-    query_params = Stargate.Reader.QueryParams.build_params(query_params_config)
+    query_params =
+      case type do
+        :consumer -> Consumer.QueryParams.build_params(query_params_config)
+        :reader -> Reader.QueryParams.build_params(query_params_config)
+      end
 
     setup_state = %{
       registry: registry,
@@ -92,12 +108,12 @@ defmodule Stargate.Reader do
 
     state =
       args
-      |> Stargate.Connection.connection_settings("reader", query_params)
+      |> Stargate.Connection.connection_settings(type, query_params)
       |> Map.merge(setup_state)
       |> (fn fields -> struct(State, fields) end).()
 
     WebSockex.start_link(state.url, __MODULE__, state,
-      name: via(state.registry, :"sg_read_#{state.tenant}_#{state.namespace}_#{state.topic}")
+      name: via(state.registry, :"sg_#{type}_#{state.tenant}_#{state.namespace}_#{state.topic}")
     )
   end
 
@@ -137,6 +153,8 @@ defmodule Stargate.Reader do
   end
 
   defp construct_response(id), do: "{\"messageId\":\"#{id}\"}"
+
+  defp construct_permit(count), do: "{\"type\":\"permit\",\"permitMessages\":#{count}}"
 
   defp current_and_next_worker(workers, index) do
     {Enum.at(workers, index), rem(index + 1, Enum.count(workers))}

--- a/lib/stargate/receiver/supervisor.ex
+++ b/lib/stargate/receiver/supervisor.ex
@@ -1,4 +1,4 @@
-defmodule Stargate.Reader.Supervisor do
+defmodule Stargate.Receiver.Supervisor do
   @moduledoc """
   TODO
   """
@@ -10,13 +10,14 @@ defmodule Stargate.Reader.Supervisor do
   """
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(args) do
+    type = Keyword.fetch!(args, :type)
     registry = Keyword.fetch!(args, :registry)
     tenant = Keyword.fetch!(args, :tenant)
     namespace = Keyword.fetch!(args, :namespace)
     topic = Keyword.fetch!(args, :topic)
 
     Supervisor.start_link(__MODULE__, args,
-      name: via(registry, :"sg_read_sup_#{tenant}_#{namespace}_#{topic}")
+      name: via(registry, :"sg_#{type}_sup_#{tenant}_#{namespace}_#{topic}")
     )
   end
 
@@ -26,11 +27,12 @@ defmodule Stargate.Reader.Supervisor do
   @impl Supervisor
   def init(args) do
     registry = Keyword.fetch!(args, :registry)
+    type = Keyword.fetch!(args, :type)
 
     children = [
-      {DynamicSupervisor, [strategy: :one_for_one, name: via(registry, :sg_worker_sup)]},
+      {DynamicSupervisor, [strategy: :one_for_one, name: via(registry, :"sg_#{type}_worker_sup")]},
       {Stargate.Receiver.WorkerManager, args},
-      {Stargate.Reader, args}
+      {Stargate.Receiver, args}
     ]
 
     Supervisor.init(children, strategy: :one_for_all)

--- a/lib/stargate/receiver/supervisor.ex
+++ b/lib/stargate/receiver/supervisor.ex
@@ -30,7 +30,8 @@ defmodule Stargate.Receiver.Supervisor do
     type = Keyword.fetch!(args, :type)
 
     children = [
-      {DynamicSupervisor, [strategy: :one_for_one, name: via(registry, :"sg_#{type}_worker_sup")]},
+      {DynamicSupervisor,
+       [strategy: :one_for_one, name: via(registry, :"sg_#{type}_worker_sup")]},
       {Stargate.Receiver.WorkerManager, args},
       {Stargate.Receiver, args}
     ]

--- a/lib/stargate/receiver/worker.ex
+++ b/lib/stargate/receiver/worker.ex
@@ -86,6 +86,6 @@ defmodule Stargate.Receiver.Worker do
   end
 
   defp ack_messages(messages, receiver) do
-    Enum.each(messages, &Stargate.Reader.ack(receiver, &1))
+    Enum.each(messages, &Stargate.Receiver.ack(receiver, &1))
   end
 end

--- a/lib/stargate/receiver/worker_manager.ex
+++ b/lib/stargate/receiver/worker_manager.ex
@@ -73,7 +73,7 @@ defmodule Stargate.Receiver.WorkerManager do
       )
 
     :ok =
-      Stargate.Reader.register_workers(
+      Stargate.Receiver.register_workers(
         receiver,
         Map.values(workers)
       )
@@ -88,7 +88,7 @@ defmodule Stargate.Receiver.WorkerManager do
       |> Map.delete(ref)
       |> start_worker(state.registry, Keyword.put(state.init_args, :receiver, receiver))
 
-    :ok = Stargate.Reader.register_workers(receiver, Map.values(new_workers))
+    :ok = Stargate.Receiver.register_workers(receiver, Map.values(new_workers))
 
     {:noreply, %{state | workers: new_workers}}
   end

--- a/lib/stargate/supervisor.ex
+++ b/lib/stargate/supervisor.ex
@@ -56,25 +56,26 @@ defmodule Stargate.Supervisor do
   defp start_consumer(_registry, _host, _protocol, nil), do: []
 
   defp start_consumer(registry, host, protocol, args) do
-    consumer_args =
-      merge_args(args, type: :consumer, host: host, protocol: protocol, registry: registry)
-
-    {Stargate.Receiver.Supervisor, consumer_args}
+    receiver_child_spec(:consumer, registry, host, protocol, args)
   end
 
   defp start_reader(_registry, _host, _protocol, nil), do: []
 
   defp start_reader(registry, host, protocol, args) do
-    reader_args =
-      merge_args(args, type: :reader, host: host, protocol: protocol, registry: registry)
-
-    {Stargate.Receiver.Supervisor, reader_args}
+    receiver_child_spec(:reader, registry, host, protocol, args)
   end
 
   defp producer_child_spec(registry, host, protocol, args) do
     producer_args = merge_args(args, host: host, protocol: protocol, registry: registry)
 
     {Stargate.Producer.Supervisor, producer_args}
+  end
+
+  defp receiver_child_spec(type, registry, host, protocol, args) do
+    receiver_args =
+      merge_args(args, type: type, registry: registry, host: host, protocol: protocol)
+
+    {Stargate.Receiver.Supervisor, receiver_args}
   end
 
   defp merge_args(args1, args2) do

--- a/lib/stargate/supervisor.ex
+++ b/lib/stargate/supervisor.ex
@@ -26,35 +26,58 @@ defmodule Stargate.Supervisor do
   def init(args) do
     name = Keyword.fetch!(args, :name)
     registry = :"sg_reg_#{name}"
+    host = Keyword.fetch!(args, :host)
+    protocol = Keyword.get(args, :protocol, "ws")
 
     children =
       [
         {Registry, name: registry, keys: :unique},
-        start_producer(registry, Keyword.get(args, :producer)),
-        start_consumer(registry, Keyword.get(args, :consumer)),
-        start_reader(registry, Keyword.get(args, :reader))
+        start_producer(registry, host, protocol, Keyword.get(args, :producer)),
+        start_consumer(registry, host, protocol, Keyword.get(args, :consumer)),
+        start_reader(registry, host, protocol, Keyword.get(args, :reader))
       ]
       |> List.flatten()
 
     Supervisor.init(children, strategy: :rest_for_one)
   end
 
-  defp start_producer(_registry, nil), do: []
+  defp start_producer(_registry, _host, _protocol, nil), do: []
 
-  defp start_producer(registry, args) do
+  defp start_producer(registry, host, protocol, args) do
     case Keyword.keyword?(args) do
-      true -> producer_child_spec(registry, args)
-      false -> Enum.map(args, fn producer -> producer_child_spec(registry, producer) end)
+      true ->
+        producer_child_spec(registry, host, protocol, args)
+
+      false ->
+        Enum.map(args, fn producer -> producer_child_spec(registry, host, protocol, producer) end)
     end
   end
 
-  defp start_consumer(_registry, nil), do: []
+  defp start_consumer(_registry, _host, _protocol, nil), do: []
 
-  defp start_reader(_registry, nil), do: []
+  defp start_consumer(registry, host, protocol, args) do
+    consumer_args =
+      merge_args(args, type: :consumer, host: host, protocol: protocol, registry: registry)
 
-  defp producer_child_spec(registry, args) do
-    producer_args = Keyword.put(args, :registry, registry)
+    {Stargate.Receiver.Supervisor, consumer_args}
+  end
+
+  defp start_reader(_registry, _host, _protocol, nil), do: []
+
+  defp start_reader(registry, host, protocol, args) do
+    reader_args =
+      merge_args(args, type: :reader, host: host, protocol: protocol, registry: registry)
+
+    {Stargate.Receiver.Supervisor, reader_args}
+  end
+
+  defp producer_child_spec(registry, host, protocol, args) do
+    producer_args = merge_args(args, host: host, protocol: protocol, registry: registry)
 
     {Stargate.Producer.Supervisor, producer_args}
+  end
+
+  defp merge_args(args1, args2) do
+    Keyword.merge(args1, args2, fn _k, _v1, v2 -> v2 end)
   end
 end


### PR DESCRIPTION
Converts the reader into a generic "receiver" socket connection that can be configured as a consumer or a reader based on the endpoint and query params passed to the initial start_link function.