### PR TITLE
testing cache restore keys

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,8 @@ jobs:
         with:
           path: .dialyzer
           key: dialyzer-plt
+          restore-keys: |
+            dialyzer-
       - name: Get dependencies
         run: |
           mix local.rebar --force

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ end
 The docs can be found at [https://hexdocs.pm/stargate](https://hexdocs.pm/stargate).
 
 ## Usage
+
 ### Produce
 Producing to Pulsar via Stargate is as simple as passing an Erlang term to the produce function. Stargate
 takes care of encoding the message payload with the necessary fields and format required by Pulsar with

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule Stargate.MixProject do
       source_url: "https://github.com/jeffgrunewald/stargate",
       elixirc_paths: elixirc_paths(Mix.env()),
       test_paths: test_paths(Mix.env()),
-      dialyzer: [plt_file: {:no_warn, ".dialyzer/#{System.version()}.plt"}]
+      dialyzer: [plt_file: {:no_warn, ".dialyzer/dialyzer-#{System.version()}.plt"}]
     ]
   end
 


### PR DESCRIPTION
Testing the ability to generate a plt cache file with a name pattern the github workflow cache action can target via the "restore-keys" option.