### PR TITLE
Registry name tuples

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,7 @@ jobs:
           elixir-version: 1.11
       - name: Retrieve cached PLT
         uses: actions/cache@v1
+        id: plt-cache
         with:
           path: .dialyzer
           key: plt-${{ github.head_ref }}
@@ -64,6 +65,13 @@ jobs:
       - name: Run formatter
         run: |
           mix format --check-formatted
+
+      - name: Create PLTs
+        if: ${{ steps.plt-cache.outputs.cache-hit != 'true' }}
+        run: |
+          mkdir -p .dialyzer
+          mix dialyzer --plt
+
       - name: Run dialyzer
         run: |
           mix dialyzer

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ helper to calculate this via-tuple easily. When supplying the `Stargate.registry
 assumes you're trying to reach the Producer process as this is the process most likely to be called directly (in conjunction within
 `Stargate.produce/2,3`), assumes a persistent topic (because Pulsar assumes topics are persistent by default) and assumes the
 Supervisor and Registry name suffix to be `:default`. If necessary, you can supply a Keyword List of options to customize the
-via-tuple returned by `Stargate.registry_key/4` with a combination of the arguments `:name`, `:component`, `:persistence`.
+via-tuple returned by `Stargate.registry_key/4` with a combination of the arguments `:name` or `:registry`, `:component`, `:persistence`.
 
 ```elixir
 iex> Stargate.registry_key("foo", "bar", "baz")

--- a/lib/stargate.ex
+++ b/lib/stargate.ex
@@ -93,10 +93,11 @@ defmodule Stargate do
           {:via, Registry, {atom(), {component(), persistence(), tenant(), namespace(), topic()}}}
   def registry_key(tenant, namespace, topic, opts \\ []) do
     name = Keyword.get(opts, :name, :default)
+    registry = Keyword.get(opts, :registry) || :"sg_reg_#{name}"
     component = Keyword.get(opts, :component, :producer)
     persistence = Keyword.get(opts, :persistence, "persistent")
 
-    {:via, Registry, {:"sg_reg_#{name}", {component, persistence, tenant, namespace, topic}}}
+    {:via, Registry, {registry, {component, persistence, tenant, namespace, topic}}}
   end
 
   defmodule Message do

--- a/lib/stargate.ex
+++ b/lib/stargate.ex
@@ -85,7 +85,7 @@ defmodule Stargate do
   @type tenant :: String.t()
   @type namespace :: String.t()
   @type topic :: String.t()
-  @type persistence :: "persistent" | "non-persistent"
+  @type persistence :: String.t()
   @type component :: :producer | :producer_ack | :consumer | :consumer_ack | :reader | :reader_ack
   @type key_opt :: {:persistence, persistence()} | {:name, atom()} | {:component, component()}
 

--- a/lib/stargate.ex
+++ b/lib/stargate.ex
@@ -82,6 +82,23 @@ defmodule Stargate do
   defdelegate produce(url_or_connection, message), to: Stargate.Producer
   defdelegate produce(connection, message, mfa), to: Stargate.Producer
 
+  @type tenant :: String.t()
+  @type namespace :: String.t()
+  @type topic :: String.t()
+  @type persistence :: "persistent" | "non-persistent"
+  @type component :: :producer | :producer_ack | :consumer | :consumer_ack | :reader | :reader_ack
+  @type key_opt :: {:persistence, persistence()} | {:name, atom()} | {:component, component()}
+
+  @spec registry_key(tenant(), namespace(), topic(), [key_opt]) ::
+          {:via, Registry, {atom(), {component(), persistence(), tenant(), namespace(), topic()}}}
+  def registry_key(tenant, namespace, topic, opts \\ []) do
+    name = Keyword.get(opts, :name, :default)
+    component = Keyword.get(opts, :component, :producer)
+    persistence = Keyword.get(opts, :persistence, "persistent")
+
+    {:via, Registry, {:"sg_reg_#{name}", {component, persistence, tenant, namespace, topic}}}
+  end
+
   defmodule Message do
     @moduledoc """
     Defines the Elixir Struct that represents the structure of a Pulsar message.

--- a/lib/stargate.ex
+++ b/lib/stargate.ex
@@ -87,8 +87,23 @@ defmodule Stargate do
   @type topic :: String.t()
   @type persistence :: String.t()
   @type component :: :producer | :producer_ack | :consumer | :consumer_ack | :reader | :reader_ack
-  @type key_opt :: {:persistence, persistence()} | {:name, atom()} | {:component, component()}
+  @type key_opt ::
+          {:persistence, persistence()}
+          | {:name, atom()}
+          | {:registry, atom()}
+          | {:component, component()}
 
+  @doc """
+  Generate the via-tuple needed for addressing a process within the Stargate supervision tree. Expects
+  at minimum the tenant, namespace, and topic of the process being addressed and assumes by default the
+  desired process is the Producer of a persistent topic managed by the default supervisor/registry.
+
+  iex> Stargate.registry_key("foo", "bar", "baz")
+  {:via, Registry, {:sg_reg_default, {:producer, "persistent", "foo", "bar", "baz"}}}
+
+  iex> Stargate.registry_key("foo", "bar", "baz", registry: MyCustom.Registry, persistence: "non-persistent", component: :producer_ack)
+  {:via, Registry, {MyCustom.Registry, {:producer_ack, "non-persistent", "foo", "bar", "baz"}}}
+  """
   @spec registry_key(tenant(), namespace(), topic(), [key_opt]) ::
           {:via, Registry, {atom(), {component(), persistence(), tenant(), namespace(), topic()}}}
   def registry_key(tenant, namespace, topic, opts \\ []) do

--- a/lib/stargate/producer.ex
+++ b/lib/stargate/producer.ex
@@ -24,7 +24,8 @@ defmodule Stargate.Producer do
   The atom key for identifying the producer in the via tuple is of
   the form `:"sg_prod_<tenant>_<namespace>_<topic>`.
   """
-  @type producer :: GenServer.server()
+  @type producer ::
+          GenServer.server() | {:via, atom(), {atom(), Stargate.Supervisor.process_key()}}
 
   @typedoc """
   Pulsar messages produced by Stargate can be any of the following forms:
@@ -65,10 +66,9 @@ defmodule Stargate.Producer do
   def produce(url, messages) when is_binary(url) do
     with [protocol, _, host, _, _, _, persistence, tenant, ns, topic | _] <-
            String.split(url, "/"),
-         name when is_atom(name) <- temp_produce_name(tenant, ns, topic),
-         opts <- temp_producer_opts(name, protocol, host, persistence, tenant, ns, topic),
+         opts <- temp_producer_opts(:temp, protocol, host, persistence, tenant, ns, topic),
          {:ok, temp_producer} <- Stargate.Supervisor.start_link(opts),
-         :ok <- produce(via(:"sg_reg_#{name}", :"sg_prod_#{tenant}_#{ns}_#{topic}"), messages) do
+         :ok <- produce(via(:sg_reg_temp, {:producer, tenant, ns, topic}), messages) do
       Process.unlink(temp_producer)
       Supervisor.stop(temp_producer)
       :ok
@@ -191,7 +191,10 @@ defmodule Stargate.Producer do
       |> Stargate.Connection.auth_settings()
       |> Keyword.put(
         :name,
-        via(state.registry, :"sg_prod_#{state.tenant}_#{state.namespace}_#{state.topic}")
+        via(
+          state.registry,
+          {:producer, "#{state.tenant}", "#{state.namespace}", "#{state.topic}"}
+        )
       )
 
     WebSockex.start_link(state.url, __MODULE__, state, server_opts)
@@ -200,7 +203,10 @@ defmodule Stargate.Producer do
   @impl WebSockex
   def handle_cast({:send, payload, ctx, ack}, state) do
     Acknowledger.produce(
-      via(state.registry, :"sg_prod_ack_#{state.tenant}_#{state.namespace}_#{state.topic}"),
+      via(
+        state.registry,
+        {:producer_ack, "#{state.tenant}", "#{state.namespace}", "#{state.topic}"}
+      ),
       ctx,
       ack
     )
@@ -219,7 +225,7 @@ defmodule Stargate.Producer do
 
     :ok =
       state.registry
-      |> via(:"sg_prod_ack_#{state.tenant}_#{state.namespace}_#{state.topic}")
+      |> via({:producer_ack, "#{state.tenant}", "#{state.namespace}", "#{state.topic}"})
       |> Acknowledger.ack(response)
 
     {:ok, state}
@@ -282,8 +288,6 @@ defmodule Stargate.Producer do
 
     {:error, reason, ctx}
   end
-
-  defp temp_produce_name(tenant, namespace, topic), do: :"#{tenant}_#{namespace}_#{topic}_temp"
 
   defp temp_producer_opts(name, protocol, host, persistence, tenant, namespace, topic) do
     [

--- a/lib/stargate/producer/acknowledger.ex
+++ b/lib/stargate/producer/acknowledger.ex
@@ -43,12 +43,13 @@ defmodule Stargate.Producer.Acknowledger do
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(init_args) do
     registry = Keyword.fetch!(init_args, :registry)
+    persistence = Keyword.get(init_args, :persistence, "persistent")
     tenant = Keyword.fetch!(init_args, :tenant)
     ns = Keyword.fetch!(init_args, :namespace)
     topic = Keyword.fetch!(init_args, :topic)
 
     GenServer.start_link(__MODULE__, init_args,
-      name: via(registry, {:producer_ack, "#{tenant}", "#{ns}", "#{topic}"})
+      name: via(registry, {:producer_ack, "#{persistence}", "#{tenant}", "#{ns}", "#{topic}"})
     )
   end
 

--- a/lib/stargate/producer/acknowledger.ex
+++ b/lib/stargate/producer/acknowledger.ex
@@ -48,7 +48,7 @@ defmodule Stargate.Producer.Acknowledger do
     topic = Keyword.fetch!(init_args, :topic)
 
     GenServer.start_link(__MODULE__, init_args,
-      name: via(registry, :"sg_prod_ack_#{tenant}_#{ns}_#{topic}")
+      name: via(registry, {:producer_ack, "#{tenant}", "#{ns}", "#{topic}"})
     )
   end
 

--- a/lib/stargate/producer/supervisor.ex
+++ b/lib/stargate/producer/supervisor.ex
@@ -17,12 +17,14 @@ defmodule Stargate.Producer.Supervisor do
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(args) do
     registry = Keyword.fetch!(args, :registry)
+    persistence = Keyword.get(args, :persistence, "persistent")
     tenant = Keyword.fetch!(args, :tenant)
     namespace = Keyword.fetch!(args, :namespace)
     topic = Keyword.fetch!(args, :topic)
 
     Supervisor.start_link(__MODULE__, args,
-      name: via(registry, {:producer_sup, "#{tenant}", "#{namespace}", "#{topic}"})
+      name:
+        via(registry, {:producer_sup, "#{persistence}", "#{tenant}", "#{namespace}", "#{topic}"})
     )
   end
 
@@ -32,12 +34,13 @@ defmodule Stargate.Producer.Supervisor do
   """
   @spec child_spec(keyword()) :: Supervisor.child_spec()
   def child_spec(args) do
+    persistence = Keyword.get(args, :persistence, "persistent")
     tenant = Keyword.fetch!(args, :tenant)
     namespace = Keyword.fetch!(args, :namespace)
     topic = Keyword.fetch!(args, :topic)
 
     Supervisor.child_spec(super(args),
-      id: {:producer_sup, "#{tenant}", "#{namespace}", "#{topic}"}
+      id: {:producer_sup, "#{persistence}", "#{tenant}", "#{namespace}", "#{topic}"}
     )
   end
 

--- a/lib/stargate/producer/supervisor.ex
+++ b/lib/stargate/producer/supervisor.ex
@@ -22,7 +22,7 @@ defmodule Stargate.Producer.Supervisor do
     topic = Keyword.fetch!(args, :topic)
 
     Supervisor.start_link(__MODULE__, args,
-      name: via(registry, :"sg_prod_sup_#{tenant}_#{namespace}_#{topic}")
+      name: via(registry, {:producer_sup, "#{tenant}", "#{namespace}", "#{topic}"})
     )
   end
 
@@ -35,7 +35,10 @@ defmodule Stargate.Producer.Supervisor do
     tenant = Keyword.fetch!(args, :tenant)
     namespace = Keyword.fetch!(args, :namespace)
     topic = Keyword.fetch!(args, :topic)
-    Supervisor.child_spec(super(args), id: :"sg_prod_sup_#{tenant}_#{namespace}_#{topic}")
+
+    Supervisor.child_spec(super(args),
+      id: {:producer_sup, "#{tenant}", "#{namespace}", "#{topic}"}
+    )
   end
 
   @impl Supervisor

--- a/lib/stargate/receiver.ex
+++ b/lib/stargate/receiver.ex
@@ -146,7 +146,8 @@ defmodule Stargate.Receiver do
         :name,
         via(
           state.registry,
-          {:"#{type}", "#{state.tenant}", "#{state.namespace}", "#{state.topic}"}
+          {:"#{type}", "#{state.persistence}", "#{state.tenant}", "#{state.namespace}",
+           "#{state.topic}"}
         )
       )
 
@@ -154,12 +155,15 @@ defmodule Stargate.Receiver do
   end
 
   @impl WebSockex
-  def handle_frame({:text, msg}, %{tenant: tenant, namespace: ns, topic: topic} = state) do
+  def handle_frame(
+        {:text, msg},
+        %{persistence: persistence, tenant: tenant, namespace: ns, topic: topic} = state
+      ) do
     Logger.debug("Received frame : #{inspect(msg)}")
 
     :ok =
       state.registry
-      |> via({:dispatcher, "#{tenant}", "#{ns}", "#{topic}"})
+      |> via({:dispatcher, "#{persistence}", "#{tenant}", "#{ns}", "#{topic}"})
       |> Dispatcher.push(msg)
 
     {:ok, state}

--- a/lib/stargate/receiver.ex
+++ b/lib/stargate/receiver.ex
@@ -144,7 +144,10 @@ defmodule Stargate.Receiver do
       |> Stargate.Connection.auth_settings()
       |> Keyword.put(
         :name,
-        via(state.registry, :"sg_#{type}_#{state.tenant}_#{state.namespace}_#{state.topic}")
+        via(
+          state.registry,
+          {:"#{type}", "#{state.tenant}", "#{state.namespace}", "#{state.topic}"}
+        )
       )
 
     WebSockex.start_link(state.url, __MODULE__, state, server_opts)
@@ -156,7 +159,7 @@ defmodule Stargate.Receiver do
 
     :ok =
       state.registry
-      |> via(:"sg_dispatcher_#{tenant}_#{ns}_#{topic}")
+      |> via({:dispatcher, "#{tenant}", "#{ns}", "#{topic}"})
       |> Dispatcher.push(msg)
 
     {:ok, state}

--- a/lib/stargate/receiver/acknowledger.ex
+++ b/lib/stargate/receiver/acknowledger.ex
@@ -43,7 +43,7 @@ defmodule Stargate.Receiver.Acknowledger do
     topic = Keyword.fetch!(init_args, :topic)
 
     GenStage.start_link(__MODULE__, init_args,
-      name: via(registry, :"sg_#{type}_ack_#{tenant}_#{ns}_#{topic}")
+      name: via(registry, {:"#{type}_ack", "#{tenant}", "#{ns}", "#{topic}"})
     )
   end
 
@@ -62,7 +62,7 @@ defmodule Stargate.Receiver.Acknowledger do
       tenant: tenant,
       namespace: ns,
       topic: topic,
-      receiver: :"sg_#{type}_#{tenant}_#{ns}_#{topic}"
+      receiver: {:"#{type}", "#{tenant}", "#{ns}", "#{topic}"}
     }
 
     subscriptions = subscriptions(registry, tenant, ns, topic, processors)
@@ -96,7 +96,7 @@ defmodule Stargate.Receiver.Acknowledger do
   end
 
   defp subscription_spec(number, registry, tenant, namespace, topic) do
-    producer = via(registry, :"sg_processor_#{tenant}_#{namespace}_#{topic}_#{number}")
+    producer = via(registry, {:processor, "#{tenant}", "#{namespace}", "#{topic}_#{number}"})
     {producer, []}
   end
 end

--- a/lib/stargate/receiver/acknowledger.ex
+++ b/lib/stargate/receiver/acknowledger.ex
@@ -23,6 +23,7 @@ defmodule Stargate.Receiver.Acknowledger do
     defstruct [
       :type,
       :registry,
+      :persistence,
       :tenant,
       :namespace,
       :topic,
@@ -38,12 +39,13 @@ defmodule Stargate.Receiver.Acknowledger do
   def start_link(init_args) do
     registry = Keyword.fetch!(init_args, :registry)
     type = Keyword.fetch!(init_args, :type)
+    persistence = Keyword.get(init_args, :persistence, "persistent")
     tenant = Keyword.fetch!(init_args, :tenant)
     ns = Keyword.fetch!(init_args, :namespace)
     topic = Keyword.fetch!(init_args, :topic)
 
     GenStage.start_link(__MODULE__, init_args,
-      name: via(registry, {:"#{type}_ack", "#{tenant}", "#{ns}", "#{topic}"})
+      name: via(registry, {:"#{type}_ack", "#{persistence}", "#{tenant}", "#{ns}", "#{topic}"})
     )
   end
 
@@ -51,6 +53,7 @@ defmodule Stargate.Receiver.Acknowledger do
   def init(init_args) do
     type = Keyword.fetch!(init_args, :type)
     registry = Keyword.fetch!(init_args, :registry)
+    persistence = Keyword.get(init_args, :persistence, "persistent")
     tenant = Keyword.fetch!(init_args, :tenant)
     ns = Keyword.fetch!(init_args, :namespace)
     topic = Keyword.fetch!(init_args, :topic)
@@ -59,13 +62,14 @@ defmodule Stargate.Receiver.Acknowledger do
     state = %State{
       type: type,
       registry: registry,
+      persistence: persistence,
       tenant: tenant,
       namespace: ns,
       topic: topic,
-      receiver: {:"#{type}", "#{tenant}", "#{ns}", "#{topic}"}
+      receiver: {:"#{type}", "#{persistence}", "#{tenant}", "#{ns}", "#{topic}"}
     }
 
-    subscriptions = subscriptions(registry, tenant, ns, topic, processors)
+    subscriptions = subscriptions(registry, persistence, tenant, ns, topic, processors)
 
     {:consumer, state, subscribe_to: subscriptions}
   end
@@ -91,12 +95,20 @@ defmodule Stargate.Receiver.Acknowledger do
     Enum.each(messages, &Stargate.Receiver.ack(receiver, &1))
   end
 
-  defp subscriptions(registry, tenant, namespace, topic, count) do
-    Enum.map(0..(count - 1), &subscription_spec(&1, registry, tenant, namespace, topic))
+  defp subscriptions(registry, persistence, tenant, namespace, topic, count) do
+    Enum.map(
+      0..(count - 1),
+      &subscription_spec(&1, registry, persistence, tenant, namespace, topic)
+    )
   end
 
-  defp subscription_spec(number, registry, tenant, namespace, topic) do
-    producer = via(registry, {:processor, "#{tenant}", "#{namespace}", "#{topic}_#{number}"})
+  defp subscription_spec(number, registry, persistence, tenant, namespace, topic) do
+    producer =
+      via(
+        registry,
+        {:processor, "#{persistence}", "#{tenant}", "#{namespace}", "#{topic}_#{number}"}
+      )
+
     {producer, []}
   end
 end

--- a/lib/stargate/receiver/dispatcher.ex
+++ b/lib/stargate/receiver/dispatcher.ex
@@ -54,7 +54,7 @@ defmodule Stargate.Receiver.Dispatcher do
     topic = Keyword.fetch!(init_args, :topic)
 
     GenStage.start_link(__MODULE__, init_args,
-      name: via(registry, :"sg_dispatcher_#{tenant}_#{ns}_#{topic}")
+      name: via(registry, {:dispatcher, "#{tenant}", "#{ns}", "#{topic}"})
     )
   end
 
@@ -77,7 +77,7 @@ defmodule Stargate.Receiver.Dispatcher do
       namespace: ns,
       topic: topic,
       pull_mode: pull,
-      receiver: :"sg_#{type}_#{tenant}_#{ns}_#{topic}"
+      receiver: {:"#{type}", "#{tenant}", "#{ns}", "#{topic}"}
     }
 
     {:ok, _receiver} = Stargate.Receiver.start_link(init_args)

--- a/lib/stargate/receiver/message_handler.ex
+++ b/lib/stargate/receiver/message_handler.ex
@@ -44,13 +44,13 @@ defmodule Stargate.Receiver.MessageHandler do
 
       def handle_message(message), do: :ack
 
-      def topic(), do: Process.get(:sg_topic)
+      def topic, do: Process.get(:sg_topic)
 
-      def namespace(), do: Process.get(:sg_namespace)
+      def namespace, do: Process.get(:sg_namespace)
 
-      def tenant(), do: Process.get(:sg_tenant)
+      def tenant, do: Process.get(:sg_tenant)
 
-      def persistence(), do: Process.get(:sg_persistence)
+      def persistence, do: Process.get(:sg_persistence)
 
       defoverridable Stargate.Receiver.MessageHandler
     end

--- a/lib/stargate/receiver/processor.ex
+++ b/lib/stargate/receiver/processor.ex
@@ -81,7 +81,8 @@ defmodule Stargate.Receiver.Processor do
     dispatcher =
       via(
         state.registry,
-        {:dispatcher, "#{state.tenant}", "#{state.namespace}", "#{state.topic}"}
+        {:dispatcher, "#{state.persistence}", "#{state.tenant}", "#{state.namespace}",
+         "#{state.topic}"}
       )
 
     {:ok, handler_state} = state.handler.init(state.handler_init_args)

--- a/lib/stargate/receiver/processor.ex
+++ b/lib/stargate/receiver/processor.ex
@@ -79,7 +79,10 @@ defmodule Stargate.Receiver.Processor do
     Process.put(:sg_persistence, state.persistence)
 
     dispatcher =
-      via(state.registry, :"sg_dispatcher_#{state.tenant}_#{state.namespace}_#{state.topic}")
+      via(
+        state.registry,
+        {:dispatcher, "#{state.tenant}", "#{state.namespace}", "#{state.topic}"}
+      )
 
     {:ok, handler_state} = state.handler.init(state.handler_init_args)
 

--- a/lib/stargate/receiver/supervisor.ex
+++ b/lib/stargate/receiver/supervisor.ex
@@ -24,7 +24,7 @@ defmodule Stargate.Receiver.Supervisor do
     topic = Keyword.fetch!(args, :topic)
 
     Supervisor.start_link(__MODULE__, args,
-      name: via(registry, :"sg_#{type}_sup_#{tenant}_#{namespace}_#{topic}")
+      name: via(registry, {:"#{type}_sup", "#{tenant}", "#{namespace}", "#{topic}"})
     )
   end
 
@@ -59,7 +59,7 @@ defmodule Stargate.Receiver.Supervisor do
     tenant = Keyword.fetch!(init_args, :tenant)
     ns = Keyword.fetch!(init_args, :namespace)
     topic = Keyword.fetch!(init_args, :topic)
-    name = :"sg_processor_#{tenant}_#{ns}_#{topic}_#{number}"
+    name = {:processor, "#{tenant}", "#{ns}", "#{topic}_#{number}"}
     named_args = Keyword.put(init_args, :processor_name, name)
 
     Supervisor.child_spec({Stargate.Receiver.Processor, named_args}, id: name)

--- a/lib/stargate/receiver/supervisor.ex
+++ b/lib/stargate/receiver/supervisor.ex
@@ -19,12 +19,14 @@ defmodule Stargate.Receiver.Supervisor do
   def start_link(args) do
     type = Keyword.fetch!(args, :type)
     registry = Keyword.fetch!(args, :registry)
+    persistence = Keyword.get(args, :persistence, "persistent")
     tenant = Keyword.fetch!(args, :tenant)
     namespace = Keyword.fetch!(args, :namespace)
     topic = Keyword.fetch!(args, :topic)
 
     Supervisor.start_link(__MODULE__, args,
-      name: via(registry, {:"#{type}_sup", "#{tenant}", "#{namespace}", "#{topic}"})
+      name:
+        via(registry, {:"#{type}_sup", "#{persistence}", "#{tenant}", "#{namespace}", "#{topic}"})
     )
   end
 
@@ -56,10 +58,11 @@ defmodule Stargate.Receiver.Supervisor do
   end
 
   defp to_child_spec(number, init_args) do
+    persistence = Keyword.get(init_args, :persistence, "persistent")
     tenant = Keyword.fetch!(init_args, :tenant)
     ns = Keyword.fetch!(init_args, :namespace)
     topic = Keyword.fetch!(init_args, :topic)
-    name = {:processor, "#{tenant}", "#{ns}", "#{topic}_#{number}"}
+    name = {:processor, "#{persistence}", "#{tenant}", "#{ns}", "#{topic}_#{number}"}
     named_args = Keyword.put(init_args, :processor_name, name)
 
     Supervisor.child_spec({Stargate.Receiver.Processor, named_args}, id: name)

--- a/lib/stargate/supervisor.ex
+++ b/lib/stargate/supervisor.ex
@@ -7,7 +7,7 @@ defmodule Stargate.Supervisor do
   """
   use Supervisor
 
-  @type process_key :: {atom(), String.t(), String.t(), String.t()}
+  @type process_key :: {atom(), String.t(), String.t(), String.t(), String.t()}
 
   @doc """
   Convenience function for working with the Stargate process registry.

--- a/lib/stargate/supervisor.ex
+++ b/lib/stargate/supervisor.ex
@@ -7,10 +7,12 @@ defmodule Stargate.Supervisor do
   """
   use Supervisor
 
+  @type process_key :: {atom(), String.t(), String.t(), String.t()}
+
   @doc """
   Convenience function for working with the Stargate process registry.
   """
-  @spec via(atom(), atom()) :: {:via, atom(), tuple()}
+  @spec via(atom(), process_key()) :: {:via, atom(), {atom(), process_key()}}
   def via(registry, name) do
     {:via, Registry, {registry, name}}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Stargate.MixProject do
   def project() do
     [
       app: :stargate,
-      version: "0.1.2",
+      version: "0.2.0",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/integration/producer_receiver_test.exs
+++ b/test/integration/producer_receiver_test.exs
@@ -34,7 +34,7 @@ defmodule Stargate.ProducerReceiverTest do
         )
 
       Stargate.produce(
-        {:via, Registry, {:sg_reg_default, :"sg_prod_#{tenant}_#{namespace}_#{topic}"}},
+        {:via, Registry, {:sg_reg_default, {:producer, "#{tenant}", "#{namespace}", "#{topic}"}}},
         input
       )
 
@@ -106,7 +106,7 @@ defmodule Stargate.ProducerReceiverTest do
         )
 
       Stargate.produce(
-        {:via, Registry, {:sg_reg_default, :"sg_prod_#{tenant}_#{namespace}_#{topic}"}},
+        {:via, Registry, {:sg_reg_default, {:producer, "#{tenant}", "#{namespace}", "#{topic}"}}},
         input
       )
 
@@ -158,7 +158,7 @@ defmodule Stargate.ProducerReceiverTest do
         )
 
       Stargate.produce(
-        {:via, Registry, {:sg_reg_default, :"sg_prod_#{tenant}_#{namespace}_#{topic}"}},
+        {:via, Registry, {:sg_reg_default, {:producer, "#{tenant}", "#{namespace}", "#{topic}"}}},
         input
       )
 

--- a/test/integration/producer_receiver_test.exs
+++ b/test/integration/producer_receiver_test.exs
@@ -33,11 +33,8 @@ defmodule Stargate.ProducerReceiverTest do
           ]
         )
 
-      Stargate.produce(
-        {:via, Registry,
-         {:sg_reg_default, {:producer, "persistent", "#{tenant}", "#{namespace}", "#{topic}"}}},
-        input
-      )
+      Stargate.registry_key(tenant, namespace, topic)
+      |> Stargate.produce(input)
 
       Supervisor.stop(producer)
 
@@ -106,11 +103,8 @@ defmodule Stargate.ProducerReceiverTest do
           consumer: consumer_opts
         )
 
-      Stargate.produce(
-        {:via, Registry,
-         {:sg_reg_default, {:producer, "persistent", "#{tenant}", "#{namespace}", "#{topic}"}}},
-        input
-      )
+      Stargate.registry_key(tenant, namespace, topic)
+      |> Stargate.produce(input)
 
       Enum.random([consumer1, consumer2]) |> Supervisor.stop()
 
@@ -159,11 +153,8 @@ defmodule Stargate.ProducerReceiverTest do
           ]
         )
 
-      Stargate.produce(
-        {:via, Registry,
-         {:sg_reg_default, {:producer, "persistent", "#{tenant}", "#{namespace}", "#{topic}"}}},
-        input
-      )
+      Stargate.registry_key(tenant, namespace, topic)
+      |> Stargate.produce(input)
 
       assert_async(10, 150, fn ->
         result = Agent.get(:integration_store, fn store -> store end) |> Enum.sort()

--- a/test/integration/producer_receiver_test.exs
+++ b/test/integration/producer_receiver_test.exs
@@ -34,7 +34,8 @@ defmodule Stargate.ProducerReceiverTest do
         )
 
       Stargate.produce(
-        {:via, Registry, {:sg_reg_default, {:producer, "#{tenant}", "#{namespace}", "#{topic}"}}},
+        {:via, Registry,
+         {:sg_reg_default, {:producer, "persistent", "#{tenant}", "#{namespace}", "#{topic}"}}},
         input
       )
 
@@ -106,7 +107,8 @@ defmodule Stargate.ProducerReceiverTest do
         )
 
       Stargate.produce(
-        {:via, Registry, {:sg_reg_default, {:producer, "#{tenant}", "#{namespace}", "#{topic}"}}},
+        {:via, Registry,
+         {:sg_reg_default, {:producer, "persistent", "#{tenant}", "#{namespace}", "#{topic}"}}},
         input
       )
 
@@ -158,7 +160,8 @@ defmodule Stargate.ProducerReceiverTest do
         )
 
       Stargate.produce(
-        {:via, Registry, {:sg_reg_default, {:producer, "#{tenant}", "#{namespace}", "#{topic}"}}},
+        {:via, Registry,
+         {:sg_reg_default, {:producer, "persistent", "#{tenant}", "#{namespace}", "#{topic}"}}},
         input
       )
 

--- a/test/support/mock_producer.ex
+++ b/test/support/mock_producer.ex
@@ -5,6 +5,7 @@ defmodule MockProducer do
 
   def start_link(init_args) do
     registry = Keyword.get(init_args, :registry)
+    persistence = Keyword.get(init_args, :persistence, "persistent")
     tenant = Keyword.get(init_args, :tenant)
     ns = Keyword.get(init_args, :namespace)
     topic = Keyword.get(init_args, :topic)
@@ -12,8 +13,8 @@ defmodule MockProducer do
 
     name =
       case type do
-        :dispatcher -> {:dispatcher, "#{tenant}", "#{ns}", "#{topic}"}
-        :processor -> {:processor, "#{tenant}", "#{ns}", "#{topic}_0"}
+        :dispatcher -> {:dispatcher, "#{persistence}", "#{tenant}", "#{ns}", "#{topic}"}
+        :processor -> {:processor, "#{persistence}", "#{tenant}", "#{ns}", "#{topic}_0"}
       end
 
     GenStage.start_link(__MODULE__, init_args, name: {:via, Registry, {registry, name}})

--- a/test/support/mock_producer.ex
+++ b/test/support/mock_producer.ex
@@ -12,8 +12,8 @@ defmodule MockProducer do
 
     name =
       case type do
-        :dispatcher -> :"sg_dispatcher_#{tenant}_#{ns}_#{topic}"
-        :processor -> :"sg_processor_#{tenant}_#{ns}_#{topic}_0"
+        :dispatcher -> {:dispatcher, "#{tenant}", "#{ns}", "#{topic}"}
+        :processor -> {:processor, "#{tenant}", "#{ns}", "#{topic}_0"}
       end
 
     GenStage.start_link(__MODULE__, init_args, name: {:via, Registry, {registry, name}})

--- a/test/support/mock_socket.ex
+++ b/test/support/mock_socket.ex
@@ -114,7 +114,7 @@ defmodule SampleClient do
   use Stargate.Connection
 
   def cast(message), do: WebSockex.cast(__MODULE__, {:send, message})
-  def ping_socket(), do: send(__MODULE__, :send_ping)
+  def ping_socket, do: send(__MODULE__, :send_ping)
 
   def start_link(init_args) do
     port = Keyword.get(init_args, :port)

--- a/test/support/mock_socket.ex
+++ b/test/support/mock_socket.ex
@@ -4,7 +4,7 @@ defmodule MockSocket.Supervisor do
   use Supervisor
 
   def start_link(init_args) do
-    Supervisor.start_link(__MODULE__, init_args, name: __MODULE__)
+    Supervisor.start_link(__MODULE__, init_args)
   end
 
   def init(init_args) do

--- a/test/unit/stargate/consumer/query_params_test.exs
+++ b/test/unit/stargate/consumer/query_params_test.exs
@@ -1,11 +1,13 @@
 defmodule Stargate.Consumer.QueryParamsTest do
   use ExUnit.Case
 
+  alias Stargate.Consumer.QueryParams
+
   describe "Consumer query params" do
     test "returns default (empty) query params" do
       input = %{}
 
-      assert "" == Stargate.Consumer.QueryParams.build_params(input)
+      assert "" == QueryParams.build_params(input)
     end
 
     test "returns custom query params" do
@@ -19,7 +21,7 @@ defmodule Stargate.Consumer.QueryParamsTest do
       result =
         "ackTimeoutMillis=2000&pullMode=true&receiverQueueSize=500&subscriptionType=Exclusive"
 
-      assert result == Stargate.Consumer.QueryParams.build_params(input)
+      assert result == QueryParams.build_params(input)
     end
   end
 end

--- a/test/unit/stargate/producer/acknowledger_test.exs
+++ b/test/unit/stargate/producer/acknowledger_test.exs
@@ -2,6 +2,8 @@ defmodule Stargate.Producer.AcknowledgerTest do
   use ExUnit.Case
   import ExUnit.CaptureLog
 
+  alias Stargate.Producer.Acknowledger, as: ProdAcknowledger
+
   setup do
     opts = [
       registry: :sg_reg_test_acknowledger,
@@ -11,7 +13,7 @@ defmodule Stargate.Producer.AcknowledgerTest do
     ]
 
     {:ok, registry} = Registry.start_link(keys: :unique, name: :sg_reg_test_acknowledger)
-    {:ok, acknowledger} = Stargate.Producer.Acknowledger.start_link(opts)
+    {:ok, acknowledger} = ProdAcknowledger.start_link(opts)
 
     on_exit(fn ->
       kill(acknowledger)
@@ -23,16 +25,16 @@ defmodule Stargate.Producer.AcknowledgerTest do
 
   describe "synchronous ack" do
     test "tracks a produce and acknowledges to sender", %{acknowledger: acknowledger} do
-      :ok = Stargate.Producer.Acknowledger.produce(acknowledger, "123", self())
+      :ok = ProdAcknowledger.produce(acknowledger, "123", self())
 
-      :ok = Stargate.Producer.Acknowledger.ack(acknowledger, {:ack, "123"})
+      :ok = ProdAcknowledger.ack(acknowledger, {:ack, "123"})
       assert_receive :ack
     end
 
     test "returns errors to the sender", %{acknowledger: acknowledger} do
-      :ok = Stargate.Producer.Acknowledger.produce(acknowledger, "234", self())
+      :ok = ProdAcknowledger.produce(acknowledger, "234", self())
 
-      :ok = Stargate.Producer.Acknowledger.ack(acknowledger, {:error, "whoops", "234"})
+      :ok = ProdAcknowledger.ack(acknowledger, {:error, "whoops", "234"})
 
       assert_receive {:error, "whoops"}
     end
@@ -41,13 +43,13 @@ defmodule Stargate.Producer.AcknowledgerTest do
   describe "asynchronous ack" do
     test "tracks a produce and executes the saved function", %{acknowledger: acknowledger} do
       :ok =
-        Stargate.Producer.Acknowledger.produce(
+        ProdAcknowledger.produce(
           acknowledger,
           "123",
           {Kernel, :send, [self(), "async_ack"]}
         )
 
-      :ok = Stargate.Producer.Acknowledger.ack(acknowledger, {:ack, "123"})
+      :ok = ProdAcknowledger.ack(acknowledger, {:ack, "123"})
 
       assert_receive "async_ack"
     end
@@ -55,13 +57,13 @@ defmodule Stargate.Producer.AcknowledgerTest do
     test "logs errors when they occur during async ack", %{acknowledger: acknowledger} do
       ack_function = fn ->
         :ok =
-          Stargate.Producer.Acknowledger.produce(
+          ProdAcknowledger.produce(
             acknowledger,
             "234",
             {Kernel, :send, [self(), "async_ack_error"]}
           )
 
-        :ok = Stargate.Producer.Acknowledger.ack(acknowledger, {:error, "oh nooo", "234"})
+        :ok = ProdAcknowledger.ack(acknowledger, {:error, "oh nooo", "234"})
 
         Process.sleep(10)
       end

--- a/test/unit/stargate/producer/query_params_test.exs
+++ b/test/unit/stargate/producer/query_params_test.exs
@@ -1,11 +1,13 @@
 defmodule Stargate.Producer.QueryParamsTest do
   use ExUnit.Case
 
+  alias Stargate.Producer.QueryParams
+
   describe "Producer query params" do
     test "returns default (empty) query params" do
       input = %{}
 
-      assert "" == Stargate.Producer.QueryParams.build_params(input)
+      assert "" == QueryParams.build_params(input)
     end
 
     test "returns custom query params" do
@@ -20,7 +22,7 @@ defmodule Stargate.Producer.QueryParamsTest do
       result =
         "compressionType=ZLIB&initialSequenceId=2500000000&messageRoutingMode=RoundRobinPartition&producerName=foobar&sendTimeoutMillis=3000"
 
-      assert result == Stargate.Producer.QueryParams.build_params(input)
+      assert result == QueryParams.build_params(input)
     end
   end
 end

--- a/test/unit/stargate/producer_test.exs
+++ b/test/unit/stargate/producer_test.exs
@@ -103,7 +103,9 @@ defmodule Stargate.ProducerTest do
       ]
 
       {:ok, _supervisor} = Stargate.Supervisor.start_link(opts)
-      [{producer, _}] = Registry.lookup(:sg_reg_produce_3_test, :sg_prod_default_public_foobar)
+
+      [{producer, _}] =
+        Registry.lookup(:sg_reg_produce_3_test, {:producer, "default", "public", "foobar"})
 
       test = self()
 

--- a/test/unit/stargate/producer_test.exs
+++ b/test/unit/stargate/producer_test.exs
@@ -105,7 +105,10 @@ defmodule Stargate.ProducerTest do
       {:ok, _supervisor} = Stargate.Supervisor.start_link(opts)
 
       [{producer, _}] =
-        Registry.lookup(:sg_reg_produce_3_test, {:producer, "default", "public", "foobar"})
+        Registry.lookup(
+          :sg_reg_produce_3_test,
+          {:producer, "persistent", "default", "public", "foobar"}
+        )
 
       test = self()
 

--- a/test/unit/stargate/reader/query_params_test.exs
+++ b/test/unit/stargate/reader/query_params_test.exs
@@ -1,11 +1,13 @@
 defmodule Stargate.Reader.QueryParamsTest do
   use ExUnit.Case
 
+  alias Stargate.Reader.QueryParams
+
   describe "Reader query params" do
     test "returns default (empty) query params" do
       input = %{}
 
-      assert "" == Stargate.Reader.QueryParams.build_params(input)
+      assert "" == QueryParams.build_params(input)
     end
 
     test "returns custom query params" do
@@ -17,7 +19,7 @@ defmodule Stargate.Reader.QueryParamsTest do
 
       result = "messageId=Dkx4SCF==&readerName=foobar&receiverQueueSize=500"
 
-      assert result == Stargate.Reader.QueryParams.build_params(input)
+      assert result == QueryParams.build_params(input)
     end
   end
 end

--- a/test/unit/stargate/receiver/acknowledger_test.exs
+++ b/test/unit/stargate/receiver/acknowledger_test.exs
@@ -1,6 +1,8 @@
 defmodule Stargate.Receiver.AcknowledgerTest do
   use ExUnit.Case
 
+  alias Stargate.Receiver.Acknowledger, as: RecAcknowledger
+
   setup do
     tenant = "public"
     ns = "default"
@@ -34,7 +36,7 @@ defmodule Stargate.Receiver.AcknowledgerTest do
       )
 
     {:ok, receiver} = Stargate.Receiver.start_link(opts)
-    {:ok, acknowledger} = Stargate.Receiver.Acknowledger.start_link(opts)
+    {:ok, acknowledger} = RecAcknowledger.start_link(opts)
 
     on_exit(fn ->
       Enum.each([registry, producer, receiver, acknowledger, server], &kill/1)

--- a/test/unit/stargate/receiver/dispatcher_test.exs
+++ b/test/unit/stargate/receiver/dispatcher_test.exs
@@ -1,6 +1,8 @@
 defmodule Stargate.Receiver.DispatcherTest do
   use ExUnit.Case
 
+  alias Stargate.Receiver.Dispatcher
+
   setup do
     reg_name = :sg_reg_dispatcher_test
     type = :reader
@@ -21,7 +23,7 @@ defmodule Stargate.Receiver.DispatcherTest do
 
     {:ok, registry} = Registry.start_link(keys: :unique, name: reg_name)
     {:ok, server} = MockSocket.Supervisor.start_link(port: port, path: path, source: self())
-    {:ok, dispatcher} = Stargate.Receiver.Dispatcher.start_link(opts)
+    {:ok, dispatcher} = Dispatcher.start_link(opts)
     {:ok, consumer} = MockConsumer.start_link(producer: dispatcher, source: self())
 
     on_exit(fn ->
@@ -33,7 +35,7 @@ defmodule Stargate.Receiver.DispatcherTest do
 
   describe "push/2" do
     test "generates events for each message pushed", %{dispatcher: dispatcher} do
-      :ok = Stargate.Receiver.Dispatcher.push(dispatcher, ["message1", "message2"])
+      :ok = Dispatcher.push(dispatcher, ["message1", "message2"])
 
       assert_receive {:event_received, ["message1", "message2"]}
     end

--- a/test/unit/stargate/receiver/processor_test.exs
+++ b/test/unit/stargate/receiver/processor_test.exs
@@ -1,6 +1,8 @@
 defmodule Stargate.Receiver.ProcessorTest do
   use ExUnit.Case
 
+  alias Stargate.Receiver.Processor
+
   setup do
     tenant = "default"
     ns = "public"
@@ -29,7 +31,7 @@ defmodule Stargate.Receiver.ProcessorTest do
         type: :dispatcher
       )
 
-    {:ok, processor} = Stargate.Receiver.Processor.start_link(opts)
+    {:ok, processor} = Processor.start_link(opts)
     {:ok, consumer} = MockConsumer.start_link(producer: processor)
 
     on_exit(fn ->

--- a/test/unit/stargate/receiver_test.exs
+++ b/test/unit/stargate/receiver_test.exs
@@ -25,7 +25,7 @@ defmodule Stargate.ReceiverTest do
     {:ok, server} = MockSocket.Supervisor.start_link(port: port, path: path, source: self())
     {:ok, dispatcher} = Stargate.Receiver.Dispatcher.start_link(opts)
     {:ok, consumer} = MockConsumer.start_link(producer: dispatcher, source: self())
-    receiver = {:via, Registry, {reg_name, :"sg_#{type}_#{tenant}_#{ns}_#{topic}"}}
+    receiver = {:via, Registry, {reg_name, {:"#{type}", "#{tenant}", "#{ns}", "#{topic}"}}}
 
     on_exit(fn ->
       Enum.map([registry, server, dispatcher, consumer], &kill/1)

--- a/test/unit/stargate/receiver_test.exs
+++ b/test/unit/stargate/receiver_test.exs
@@ -25,7 +25,9 @@ defmodule Stargate.ReceiverTest do
     {:ok, server} = MockSocket.Supervisor.start_link(port: port, path: path, source: self())
     {:ok, dispatcher} = Stargate.Receiver.Dispatcher.start_link(opts)
     {:ok, consumer} = MockConsumer.start_link(producer: dispatcher, source: self())
-    receiver = {:via, Registry, {reg_name, {:"#{type}", "#{tenant}", "#{ns}", "#{topic}"}}}
+
+    receiver =
+      {:via, Registry, {reg_name, {:"#{type}", "persistent", "#{tenant}", "#{ns}", "#{topic}"}}}
 
     on_exit(fn ->
       Enum.map([registry, server, dispatcher, consumer], &kill/1)


### PR DESCRIPTION
Addresses the majority of concerns raised in https://github.com/jeffgrunewald/stargate/issues/21 with respect to:
* Better defining the API for locating processes that need to have messages sent to them
* Converts potentially unsafe atom interpolated process names to via-tuples with string values
* Exposes the new API as a helper function at the top level of the library to easily generate the via tuple needed to locate/message a process, setting the default to the most commonly needed values.