### PR TITLE
Fix synchronous produce selective receive

### DIFF
--- a/lib/stargate/producer/acknowledger.ex
+++ b/lib/stargate/producer/acknowledger.ex
@@ -68,8 +68,8 @@ defmodule Stargate.Producer.Acknowledger do
     {value, new_state} = Map.pop(state, ctx)
 
     case value do
-      pid when is_pid(pid) ->
-        send(pid, :ack)
+      {pid, ref} when is_pid(pid) ->
+        send(pid, {ref, :ack})
 
       {module, function, args} ->
         apply(module, function, args)
@@ -83,8 +83,8 @@ defmodule Stargate.Producer.Acknowledger do
     {value, new_state} = Map.pop(state, ctx)
 
     case value do
-      pid when is_pid(pid) ->
-        send(pid, {:error, reason})
+      {pid, ref} when is_pid(pid) ->
+        send(pid, {ref, :error, reason})
 
       _mfa ->
         Logger.error("Failed to execute produce for reason : #{inspect(reason)}")

--- a/test/unit/stargate/producer/acknowledger_test.exs
+++ b/test/unit/stargate/producer/acknowledger_test.exs
@@ -25,18 +25,20 @@ defmodule Stargate.Producer.AcknowledgerTest do
 
   describe "synchronous ack" do
     test "tracks a produce and acknowledges to sender", %{acknowledger: acknowledger} do
-      :ok = ProdAcknowledger.produce(acknowledger, "123", self())
+      ref = make_ref()
+      :ok = ProdAcknowledger.produce(acknowledger, "123", {self(), ref})
 
       :ok = ProdAcknowledger.ack(acknowledger, {:ack, "123"})
-      assert_receive :ack
+      assert_receive {^ref, :ack}
     end
 
     test "returns errors to the sender", %{acknowledger: acknowledger} do
-      :ok = ProdAcknowledger.produce(acknowledger, "234", self())
+      ref = make_ref()
+      :ok = ProdAcknowledger.produce(acknowledger, "234", {self(), ref})
 
       :ok = ProdAcknowledger.ack(acknowledger, {:error, "whoops", "234"})
 
-      assert_receive {:error, "whoops"}
+      assert_receive {^ref, :error, "whoops"}
     end
   end
 


### PR DESCRIPTION
Relates to https://github.com/jeffgrunewald/stargate/issues/22.
This improves the selective receive so that it doesn't mistake
a completely different message for a produce error.
I kept it simple for now. If you look at how `:gen.call` is implemented,
you'll see that is a lot more complex involving process monitors and
timeouts.
I wanted to add a timeout now, but this adds an extra param,
making the `produce/2` a `produce/3` which clashes with the existing
`produce/3`, so I left that out for now.